### PR TITLE
(QENG-1796) Improved error recovery

### DIFF
--- a/lib/telly.rb
+++ b/lib/telly.rb
@@ -133,7 +133,7 @@ module Telly
     results[:passes].each do |junit_result|
       begin
         submit_result(api, PASSED, junit_result, junit_file, testrun_id)    
-      rescue TestRail::APIError => e
+      rescue Exception => e
         bad_results[junit_result[:name]] = e.message
       end
     end
@@ -141,8 +141,8 @@ module Telly
     # Failures
     results[:failures].each do |junit_result|
       begin
-        submit_result(api, FAILED, junit_result, junit_file, testrun_id)    
-      rescue TestRail::APIError => e
+        submit_result(api, FAILED, junit_result, junit_file, testrun_id)
+      rescue Exception => e
         bad_results[junit_result[:name]] = e.message
       end
     end
@@ -150,8 +150,8 @@ module Telly
     # Skips
     results[:skips].each do |junit_result|
       begin
-        submit_result(api, BLOCKED, junit_result, junit_file, testrun_id)    
-      rescue TestRail::APIError => e
+        submit_result(api, BLOCKED, junit_result, junit_file, testrun_id)
+      rescue Exception => e
         bad_results[junit_result[:name]] = e.message
       end
     end
@@ -168,7 +168,7 @@ module Telly
   # @param [String] testrun_id The testrun ID
   #
   # @return [Void]
-  # 
+  #
   # @raise [TestRail::APIError] When there is a problem with the API request, testrail raises
   #                             this exception. Should be caught for error reporting
   #
@@ -196,7 +196,7 @@ module Telly
     puts "\nSetting result for test case: #{testcase_id}"
     puts "Adding comment:\n#{testrail_comment}"
 
-    api.send_post("add_result_for_case/#{testrun_id}/#{testcase_id}", 
+    api.send_post("add_result_for_case/#{testrun_id}/#{testcase_id}",
       {
         status_id: status,
         comment: testrail_comment,
@@ -207,10 +207,10 @@ module Telly
 
 
   # Returns a string that testrail accepts as an elapsed time
-  # Input from beaker is a float in seconds, so it rounds it to the 
+  # Input from beaker is a float in seconds, so it rounds it to the
   # nearest second, and adds an 's' at the end
-  # 
-  # Testrail throws an exception if it gets "0s", so it returns a 
+  #
+  # Testrail throws an exception if it gets "0s", so it returns a
   # minimum of "1s"
   #
   # @param [String] seconds_string A string that contains only a number, the elapsed time of a test
@@ -233,11 +233,11 @@ module Telly
   ##################################
 
   # Loads the results of a beaker run.
-  # Returns hash of failures, passes, and skips that each hold a list of 
+  # Returns hash of failures, passes, and skips that each hold a list of
   # junit xml objects
   #
   # @param [String] junit_file Path to a junit xml file
-  # 
+  #
   # @return [Hash] A hash containing xml objects for the failures, skips, and passes
   #
   # @example load_junit_results("~/junit/latest/beaker_junit.xml")
@@ -255,13 +255,15 @@ module Telly
   # Extracts the test case id from the test script
   #
   # @param [String] beaker_file Path to a beaker test script
-  # 
+  #
   # @return [String] The test case ID
   #
   # @example testcase_id_from_beaker_script("~/tests/test_the_things.rb") # 1234
   def Telly.testcase_id_from_beaker_script(beaker_file)
     # Find first matching line
     match = File.readlines(beaker_file).map { |line| line.match(TESTCASE_ID_REGEX) }.compact.first
+
+    raise Exception, 'Testcase ID could not be found in file' if match.nil?
 
     match[:testrun_id]
   end


### PR DESCRIPTION
Previously only testrail api errors were caught and shown to the
user, now any exception that happens during submission is caught
and that test is reported to the user.

In addition, when a beaker test file doesn't contain a testcase id
it raises an exception with an appropriate error.

This PR was motivated by pre-suites not having testcase ids
causing the script to throw an uncaught exception.
