### PR TITLE
(QENG-2616) Telly - Cannot Find Test Files Using Beaker...

### DIFF
--- a/lib/telly/arg_parser.rb
+++ b/lib/telly/arg_parser.rb
@@ -34,6 +34,10 @@ module Telly
           options_hash[:junit_file] = junit_file
         end
 
+        parser.on( '-d', '--dry-run', 'Run without API connection to TestRail' ) do
+          options_hash[:dry_run] = true
+        end
+
         parser.on( '-h', '--help', 'Display this screen' ) do
           puts parser
           exit


### PR DESCRIPTION
... 2.8+ Logs/JUnit Reports
- beaker added a directory level that telly couldn't handle
- addeds support for --dry-run, which just process the junit file
  without creating a TestRail api connection or attempting to submit
  results
